### PR TITLE
fix getting response body when stream is set

### DIFF
--- a/pytest_falcon/plugin.py
+++ b/pytest_falcon/plugin.py
@@ -132,7 +132,7 @@ class Client(object):
         body = self.app(create_environ(path, **kwargs), resp)
         resp.headers = resp.headers_dict
         resp.status_code = int(resp.status.split(' ')[0])
-        resp.body = b''.join(list(body)) if body else ''
+        resp.body = b''.join(list(body)) if body else b''
         try:
             # …to be smart and provide the response as str if it let iself
             # decode.

--- a/pytest_falcon/plugin.py
+++ b/pytest_falcon/plugin.py
@@ -132,12 +132,15 @@ class Client(object):
         body = self.app(create_environ(path, **kwargs), resp)
         resp.headers = resp.headers_dict
         resp.status_code = int(resp.status.split(' ')[0])
-        resp.body = body[0] if body else b''
+        try:
+            resp.body = body[0] if body else ''
+        except TypeError:
+            resp.body = b''.join(list(body))
         try:
             # …to be smart and provide the response as str if it let iself
             # decode.
             resp.body = resp.body.decode()
-        except UnicodeDecodeError:
+        except (UnicodeDecodeError, AttributeError):
             # But do not insist.
             pass
         if 'application/json' in resp.headers.get('Content-Type', ''):

--- a/pytest_falcon/plugin.py
+++ b/pytest_falcon/plugin.py
@@ -132,10 +132,7 @@ class Client(object):
         body = self.app(create_environ(path, **kwargs), resp)
         resp.headers = resp.headers_dict
         resp.status_code = int(resp.status.split(' ')[0])
-        try:
-            resp.body = body[0] if body else ''
-        except TypeError:
-            resp.body = b''.join(list(body))
+        resp.body = b''.join(list(body)) if body else ''
         try:
             # …to be smart and provide the response as str if it let iself
             # decode.

--- a/pytest_falcon/plugin.py
+++ b/pytest_falcon/plugin.py
@@ -137,7 +137,7 @@ class Client(object):
             # …to be smart and provide the response as str if it let iself
             # decode.
             resp.body = resp.body.decode()
-        except (UnicodeDecodeError, AttributeError):
+        except UnicodeDecodeError:
             # But do not insist.
             pass
         if 'application/json' in resp.headers.get('Content-Type', ''):


### PR DESCRIPTION
Hi!
Thanks for providing that helper in first place.
I've found problem when app is settings stream on response instead of feeding data to body (falcon optimization). In that case falcon's `_get_body` returns iterator and this breaks handling body in `fake_request` method. Looks like it's simple solution for that.
