### PR TITLE
Add HEAD method to Client

### DIFF
--- a/pytest_falcon/plugin.py
+++ b/pytest_falcon/plugin.py
@@ -160,6 +160,9 @@ class Client(object):
     def get(self, path, **kwargs):
         return self.fake_request(path, method='GET', **kwargs)
 
+    def head(self, path, **kwargs):
+        return self.fake_request(path, method='HEAD', **kwargs)
+
     def post(self, path, data=None, **kwargs):
         kwargs.setdefault('headers', {})
         kwargs.setdefault('body', data or {})

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -27,6 +27,20 @@ def test_get(client):
     assert resp.json['foo'] == 'bar'
 
 
+def test_head(client):
+
+    class Resource:
+
+        def on_head(self, req, resp, **kwargs):
+            resp.set_header("foo", "bar")
+
+    application.add_route('/route', Resource())
+
+    resp = client.head('/route')
+    assert resp.status == falcon.HTTP_OK
+    assert resp.headers['foo'] == 'bar'
+
+
 def test_stream_response(client):
     here = os.path.dirname(os.path.realpath(__file__))
     filepath = os.path.join(here, 'image.jpg')


### PR DESCRIPTION
The Client did not support the HEAD method. It was not clear why
this was missing, but with Falcon supporting the HEAD method it
seems to follow that there should be support for it in the Client.