### PR TITLE
Makes `fake_request` honor bytes in Python 3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,0 @@
-[run]
-omit =
-    pytest_falcon/__init__.py

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .coverage
 build/
 dist/
+*.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,58 @@
 sudo: false
 language: python
 python:
-- '2.7'
-- '3.4'
-- '3.5'
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.6-dev"
+  - "3.7"
+  - "3.7-dev"
+  - "nightly"
+
+env:
+  global:
+    - WORKON_HOME=/home/travis/.virtualenvs
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - python: "3.6-dev"
+    - python: "3.7"
+    - python: "3.7-dev"
+    - python: "nightly"
+
 cache:
   directories:
   - "$HOME/.cache/pip"
+
 install:
-- pip install -r requirements.txt
-- pip install -r requirements-dev.txt
-- python setup.py develop
-script: py.test
+  # debugging info
+  - git --version
+
+  # installation of tox integration for travis
+  - pip install tox-travis
+
+  # installation of package
+  - pip install -r requirements-dev.txt
+  - pip install -r requirements.txt
+  - pip install -e .
+
+  # More debugging info .
+  - pip freeze
+
+script:
+  - tox --travis-after
+
 notifications:
   irc:
     channels:
-    - irc.freenode.net##ban
+      - irc.freenode.net##ban
     on_success: change
     on_failure: always
   email: false
+
 deploy:
   provider: pypi
   distributions: "sdist bdist_wheel"
@@ -27,4 +61,5 @@ deploy:
     secure: hI3aBXJNmvy96wvHXW1oDzp053s6nDHmhFSUMbLuxdcZDPbbwVkThn8SQXNdVi3d+qb0LFwYFKW7wyPH0UKBWZ9xGITIUy9dMh+9YOyb6uygQJ4Zylze7KFjCNI/iIoEY8o8cprCSEOLMyJtazndNwH3F1pEbOC9mM/9iZXzf+3hX4UfSGNyvVTA9HzcC+jViV0fr4G1wANoIeXuZ/KaOpejGWuHUGRhouDRlu/ouiCuhr6JvExB31bNth6FVaCOURqy+Sms8GAKCYeid3Td88wXIyapgRsR3TdkcYiKDpIVY7bkqjlUEFh6fK1ByDn112kad/Qmv8zQNEsuqvv41j5L+CciEN5hs2gW3OwhyWSbNpd6QmVeFOS76l6NCS8hkUrYPeJ+s4ELrFj81MPorIIQgvU7zj86HOq8ENpdjdp2Uyed9E2JBbdUYCP7HJODr/9uU/YJmxVJgSh8RqNoF5IwVkmnY7EC0saigz1j+yGEuxixi9byY5/BNRfteQj9+wd/xqpR+wneUC9JIfR4hBISH6w4VzZvY4vOLR1Xv0gSBcTwgsqGU0OJEric/iP2wnWPVeyS+hPWybCGKZufae+jPG0gVx3F1XKaDOp4YSQF1zG1lR0G/OBMIVH5us+f1InhdPzNZCyiwX2mwHfe8KgadeYb4eaACwuyIoCDOk4=
   on:
     tags: true
+    python: 3.6
     repo: yohanboniface/pytest-falcon

--- a/README.md
+++ b/README.md
@@ -56,3 +56,46 @@ Response properties:
 - `headers` the response headers
 - `status` the response status, as `str` ('200 OK', '405 Method Not Allowed'…)
 - `status_code` the response status code, as `int` (200, 201…)
+
+
+## Contributing
+
+As a general rule, please make sure any changes pass all tests and that
+any new contribution which fixes a bug or provides a new feature
+also has a new test paired with it.  The tests are all found under the
+`tests` folder.
+
+Additionally, there is an optional dependency on `falcon_multipart` and
+tests to check for compatibility with that package.  This package can
+be checked out within the github repo under:
+
+    https://github.com/yohanboniface/falcon-multipart
+
+Additionally, the optional dependency is included within
+`requirements-dev.txt`.  To install locally, run:
+
+    $ pip -r requirements-dev.txt
+
+
+### Style
+
+Pytest-falcon uses `isort` and `flake8` to manage style within this
+project.  There are tests that will fail if these styles are violated.
+
+
+### Testing Pytest-Falcon
+
+Pytest-Falcon testing is supported by `tox` and `tox` is integrated into
+travis.
+
+The expected mechanism for running a test is to simply run `pytest`
+within a `virtualenv`:
+
+    $ pip install -r requirements-dev.txt
+    $ pytest
+
+
+A safer, more robust way of testing is to use `tox`:
+
+    $ pip install -r requirements-dev.txt
+    $ tox

--- a/pytest_falcon/plugin.py
+++ b/pytest_falcon/plugin.py
@@ -140,9 +140,16 @@ class Client(object):
         environ = create_environ(path, **kwargs)
         resp.environ = environ
         body = self.app(environ, resp)
+        if body:
+            body = b''.join(
+                part.encode() if not isinstance(part, bytes) else part
+                for part in body
+                )
+        else:
+            body = b''
         resp.headers = resp.headers_dict
         resp.status_code = int(resp.status.split(' ')[0])
-        resp.body = b''.join(list(body)) if body else b''
+        resp.body = body
         try:
             # …to be smart and provide the response as str if it let iself
             # decode.

--- a/pytest_falcon/plugin.py
+++ b/pytest_falcon/plugin.py
@@ -1,8 +1,7 @@
 # -*- coding:utf-8 -*-
-
-from io import BytesIO
 import json
 import mimetypes
+from io import BytesIO
 from uuid import uuid4
 
 import pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,8 @@
+# falcon multipart
 git+https://github.com/yohanboniface/falcon-multipart
+
+# tests
+pytest-cov
+pytest-flake8
+pytest-isort
+tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,52 @@
+[tool:pytest]
+addopts = --isort --flake8
+testpaths = tests
+norecursedirs = .git .tox .cache .venv build venv* tmp* *.egg *.egg-info
+
+[flake8]
+# E116 Unexpected indentation (comment).
+# E121 Continuation line under-indented for hanging indent.
+# E123 Closing bracket does not match indentation of opening bracket's line.
+# E126 Continuation line over-indented for hanging indent.
+# E128 Continuation line under-indented for visual indent.
+# E501 Line too long (82 > 79 characters).
+# E731 Do not assign a lambda expression, use a def.
+# N??? Various naming conventions. Which are sane in general but have
+#      frequent, pragmatic reasons to violate them occasionally.
+jobs = 1
+ignore = E116,E121,E123,E126,E128,E501,E731,N801,N802,N803,N805,N806,N812,N814
+# Don't ignore E133!
+hang_closing = True
+filename = pytest_falcon/*.py
+exclude = __pycache__, build, dist
+
+[coverage:run]
+branch = True
+omit =
+    */__*.py
+    tests/*
+source =
+    pytest_falcon
+
+[coverage:html]
+title = Pytest-Falcon Test Coverage
+directory = docs/_build/html/
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    def __str__
+    def __dir__
+    if __name__ == .__main__.:
+
+[tool:isort]
+line_length = 140
+indent = '    '
+multi_line_output = 3
+length_sort = False
+combine_star = True
+not_skip = __init__.py
+force_alphabetical_sort = True
+force_alphabetical_sort_within_sections = True
+force_sort_within_sections = True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
-from setuptools import setup, find_packages
 from codecs import open  # To use a consistent encoding
 from os import path
+
+from setuptools import find_packages, setup
 
 import pytest_falcon
 
@@ -14,8 +15,10 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 def is_pkg(line):
     return line and not line.startswith(('--', 'git', '#'))
 
+
 with open('requirements.txt', encoding='utf-8') as reqs:
     install_requires = [l for l in reqs.read().split('\n') if is_pkg(l)]
+
 
 setup(
     name='pytest-falcon',
@@ -39,11 +42,12 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
-    ],
+        'Programming Language :: Python :: 3.6',
+        ],
     keywords='pytest falcon testing unittests',
     packages=find_packages(exclude=['tests']),
     install_requires=install_requires,
     extras_require={'test': ['pytest']},
     include_package_data=True,
     entry_points={'pytest11': ['falcon = pytest_falcon.plugin']},
-)
+    )

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -13,18 +13,37 @@ def app():
     return application
 
 
-def test_get(client):
+@pytest.mark.parametrize('expected', [
+    '',
+    {},
+    {'foo': 'bar'},
+    [
+        {
+            "id": 0,
+            "name": "Unknown",
+            "description": "NA"
+            },
+        {
+            "id": 1,
+            "name": "Another",
+            "description": "Dunno"
+            }
+        ],
+    ])
+def test_get(client, expected):
+
+    response_body = json.dumps(expected)
 
     class Resource:
 
         def on_get(self, req, resp, **kwargs):
-            resp.body = '{"foo": "bar"}'
+            resp.body = response_body
 
     application.add_route('/route', Resource())
 
     resp = client.get('/route')
     assert resp.status == falcon.HTTP_OK
-    assert resp.json['foo'] == 'bar'
+    assert resp.json == expected
 
 
 def test_head(client):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 
 import falcon
 import pytest

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1,5 +1,5 @@
-from io import BytesIO
 import os
+from io import BytesIO
 
 import falcon
 import pytest
@@ -24,7 +24,7 @@ def app():
     ('filecontent', 'afile.txt'),
     (b'filecontent', 'afile.txt'),
     (BytesIO(b'filecontent'), 'afile.txt'),
-])
+    ])
 def test_should_handle_files_kwarg_on_post(client, params):
 
     class Resource:

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,49 @@
+[vars]
+package_name = pytest-falcon
+project_name = pytest_falcon
+
+[tox]
+# Note: this list is ignored in travis, so it is only for local testing
+envlist = clean, py{27,36}, coverage-report
+skip_missing_interpreters = True
+
+[travis:after]
+travis = python: 3.6
+
+[testenv]
+passenv = *
+setenv =
+    PYTHONPATH = {toxinidir}
+whitelist_externals = *
+install_command = {envpython} -m pip install -q -U {opts} {packages}
+envdir = {env:WORKON_HOME}/tox-{[vars]package_name}/{envname}
+sitepackages = False
+recreate = True
+deps =
+    pytest-xdist
+    -r{toxinidir}/requirements-dev.txt
+    --editable=file:///{toxinidir}
+commands =
+    {envpython} -m pytest -n auto --cov={[vars]project_name} --cache-clear --cov-append --cov-report=term-missing "{toxinidir}" {posargs}
+
+[testenv:clean]
+recreate = false
+deps =
+    coverage
+skip_install = true
+commands =
+    find "{toxinidir}" -name '*.pyc' -delete
+    find "{toxinidir}" -name '__pycache__' -delete
+    rm -Rf "{toxinidir}/*.egg-info" "{toxinidir}/.cache" "{toxinidir}/.eggs"
+    rm -Rf "{toxinidir}/build" "{toxinidir}/dist"
+    "{envpython}" -m coverage erase
+
+[testenv:coverage-report]
+passenv = *
+setenv =
+    PYTHONPATH = {toxinidir}
+deps = coverage
+skip_install = true
+commands =
+    hash -r
+    "{envpython}" -m coverage report -m


### PR DESCRIPTION
* Fixes #8
* Updates elements within body to use `.encode` which will basically ensure that each element within body is a bytes object rather than a unicode object.  Also bonus - compatible with python 2.